### PR TITLE
Removed unnecessary ea-libcurl, ea-libcurl-devel, valgrind and perl* Provides.

### DIFF
--- a/SPECS/libcurl.spec
+++ b/SPECS/libcurl.spec
@@ -14,7 +14,7 @@
 Summary: A utility for getting files from remote servers (FTP, HTTP, and others)
 Name: %{pkg_name}
 Version: 7.53.1
-%define release_prefix 1
+%define release_prefix 2
 Release: %{release_prefix}%{?dist}.cpanel
 License: MIT
 Vendor: cPanel, Inc.
@@ -22,8 +22,6 @@ Group: Applications/Internet
 Source: %{pkg_name}-%{version}.tar.gz
 URL: http://curl.haxx.se/
 BuildRoot: %{_tmppath}/%{pkg_name}-%{version}-%{release}-root
-Provides: ea-libcurl
-Provides: valgrind, perl(getpart), perl(valgrind), perl(directories), perl(ftp)
 
 Requires: openssl
 BuildRequires: openssl-devel
@@ -44,7 +42,6 @@ authentication, ftp upload, HTTP post, file transfer resume and more.
 Summary:    The includes, libs, and man pages to develop with libcurl
 Group:      Development/Libraries
 Requires:   openssl-devel
-Provides:   ea-libcurl-devel
 
 %description devel
 libcurl is the core engine of curl; this packages contains all the libs,
@@ -117,6 +114,10 @@ install -m 755 -d %{buildroot}%{_defaultdocdir}
 %dir %{_defaultdocdir}
 
 %changelog
+* Mon Mar 20 2017 Eugene Zamriy <eugene@zamriy.info> - 7.53.1-2
+- Removed unnecessary ea-libcurl and ea-libcurl-devel Provides
+- Removed wrong valgrind and perl* Provides
+
 * Mon Mar 13 2017 Jacob Perkins <jacob.perkins@cpanel.net> - 7.53.1-1
 - Updated to 7.53.1
 

--- a/SPECS/libcurl.spec
+++ b/SPECS/libcurl.spec
@@ -23,12 +23,19 @@ Source: %{pkg_name}-%{version}.tar.gz
 URL: http://curl.haxx.se/
 BuildRoot: %{_tmppath}/%{pkg_name}-%{version}-%{release}-root
 
+Autoreq:  0
+Autoprov: 0
+
 Requires: openssl
+Requires: libssh2
+Requires: openldap
+Requires: krb5-libs
 BuildRequires: openssl-devel
 BuildRequires: valgrind
 BuildRequires: libidn libidn-devel
 BuildRequires: libssh2 libssh2-devel
 BuildRequires: openldap openldap-devel
+BuildRequires: krb5-devel
 
 %description
 curl is a client to get documents/files from servers, using any of the
@@ -115,8 +122,10 @@ install -m 755 -d %{buildroot}%{_defaultdocdir}
 
 %changelog
 * Mon Mar 20 2017 Eugene Zamriy <eugene@zamriy.info> - 7.53.1-2
-- Removed unnecessary ea-libcurl and ea-libcurl-devel Provides
-- Removed wrong valgrind and perl* Provides
+- Disable automatic Requires generation to avoid broken dependencies
+- Disable automatic Provides generation to avoid conflicts with system curl
+- Added libssh2, openldap, krb5-libs requirements
+- Added krb5-devel build requirement
 
 * Mon Mar 13 2017 Jacob Perkins <jacob.perkins@cpanel.net> - 7.53.1-1
 - Updated to 7.53.1


### PR DESCRIPTION
Each RPM package provides its name by default so there is no reason to do it manually.
Valgrind and perl(*) Provides are wrong since resulting packages don't provide those features and can possibly break other packages build.

Also, update like that is required for ea-phpXY-php-curl packages to make it work:
```diff
 Summary: A module for PHP applications that need to interface with curl
 Group: Development/Languages
 License: PHP
+Autoreq:  0
 Requires: %{?scl_prefix}php-common%{?_isa} = %{version}-%{release}
+Requires: %{ns_name}-libcurl
+BuildRequires: libssh2 libssh2-devel libidn libidn-devel
 Provides: %{?scl_prefix}php-curl = %{version}-%{release}, %{?scl_prefix}php-curl%{?_isa} = %{version}-%{release}
 
 %description curl

```